### PR TITLE
[nix] Add to version bumping script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,8 @@
 {
   description = "Native Yandex Music desktop client";
   inputs = {
-    ymExe = {
-      url = https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.0.8.exe;
-      flake = false;
-    };
+    ymExe.url = https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.0.8.exe;
+    ymExe.flake = false;
   };
   outputs = { self, ymExe, nixpkgs, flake-utils }:
     let
@@ -23,6 +21,7 @@
             yandex-music-backgroud = yandex-music.override {
               fixQuit = false;
             };
+            generate_packages = pkgs.callPackage ./nix/generate_packages.nix {};
             default = yandex-music;
           };
         }

--- a/generate_packages.sh
+++ b/generate_packages.sh
@@ -2,43 +2,85 @@
 
 set -e
 
+TEMPDIR=
+exe_link=
+version=
+exe_name=
+exe_sha256=
+
 clear() {
     rm -rf "$TEMPDIR"
 }
 TEMPDIR="$(mktemp -d)"
 trap clear EXIT
 
-# loading json from file https://music-desktop-application.s3.yandex.net/stable/download.json
-curl -s https://music-desktop-application.s3.yandex.net/stable/download.json > "$TEMPDIR"/download.json
+check_dep() {
+    if ! command -v "$@" &>/dev/null; then
+        echo "$@" not installed. >&2
+        return 1
+    fi
+}
 
-exe_link=$(jq -r '.windows' "$TEMPDIR"/download.json)
-version="$(echo "$exe_link" | grep -oP '(?<=x64_).*(?=.exe)')"
-exe_name="$(basename "$exe_link")"
+check_deps() {
+    check_dep sed
+    check_dep curl
+    check_dep jq
+}
 
-echo "Windows url: $exe_link"
-echo "Version: $version"
-echo "Exe name: $exe_name"
+load_current_version() {
+    # loading json from file https://music-desktop-application.s3.yandex.net/stable/download.json
+    curl -s https://music-desktop-application.s3.yandex.net/stable/download.json > "$TEMPDIR"/download.json
 
-curl "$exe_link" > "$TEMPDIR/$exe_name"
+    exe_link=$(jq -r '.windows' "$TEMPDIR"/download.json)
+    version="$(echo "$exe_link" | grep -oP '(?<=x64_).*(?=.exe)')"
+    exe_name="$(basename "$exe_link")"
 
-exe_sha256="$(sha256sum "$TEMPDIR/$exe_name" | awk '{print $1}')"
+    echo "Windows url: $exe_link"
+    echo "Version: $version"
+    echo "Exe name: $exe_name"
 
-echo "Exe sha256: $exe_sha256"
+    curl "$exe_link" > "$TEMPDIR/$exe_name"
 
-rm -rf ./version_info.json
+    exe_sha256="$(sha256sum "$TEMPDIR/$exe_name" | awk '{print $1}')"
 
-echo "{
-    \"version\": \"$version\",
-    \"exe_name\": \"$exe_name\",
-    \"exe_link\": \"$exe_link\",
-    \"exe_sha256\": \"$exe_sha256\"
-}" > ./version_info.json
+    echo "Exe sha256: $exe_sha256"
+}
 
-rm -rf ./PKGBUILD
-cp ./templates/PKGBUILD ./PKGBUILD
+update_version() {
+    rm -rf ./version_info.json
 
-sed -i "s#%version%#$version#g" ./PKGBUILD
-sed -i "s#%release%#1#g" ./PKGBUILD
-sed -i "s#%exe_name%#$exe_name#g" ./PKGBUILD
-sed -i "s#%exe_link%#$exe_link#g" ./PKGBUILD
-sed -i "s#%exe_sha256%#$exe_sha256#g" ./PKGBUILD
+    cat > ./version_info.json <<EOF
+{
+    "version": "$version",
+    "exe_name": "$exe_name",
+    "exe_link": "$exe_link",
+    "exe_sha256": "$exe_sha256"
+}
+EOF
+
+}
+
+update_pkbuild() {
+    cp ./templates/PKGBUILD ./PKGBUILD
+
+    sed -i "s#%version%#$version#g" ./PKGBUILD
+    sed -i "s#%release%#1#g" ./PKGBUILD
+    sed -i "s#%exe_name%#$exe_name#g" ./PKGBUILD
+    sed -i "s#%exe_link%#$exe_link#g" ./PKGBUILD
+    sed -i "s#%exe_sha256%#$exe_sha256#g" ./PKGBUILD
+}
+
+update_flake() {
+    sed -i 's#\(ymExe\.url\s*=\s*\).*;#\1'"$exe_link"';#' ./flake.nix
+    if check_dep nix; then
+        nix flake lock --update-input ymExe
+    else
+        echo "flake.nix was updated, but nix not installed to update flake.lock"
+    fi
+}
+
+check_deps
+load_current_version
+update_version
+update_pkbuild
+update_flake

--- a/nix/generate_packages.nix
+++ b/nix/generate_packages.nix
@@ -1,0 +1,25 @@
+{ jq
+, curl
+, runCommand
+, lib
+, makeWrapper
+}:
+let
+  paths = lib.makeBinPath [ jq curl ];
+in
+runCommand "generate_config"
+{
+  src = ../generate_packages.sh;
+  name = "generate_packages";
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+} ''
+  mkdir -p "$out/bin"
+  bin="$out/bin/$name"
+  cp "$src" "$bin"
+  chmod +x "$bin"
+  patchShebangs "$bin"
+  wrapProgram "$bin" \
+    --prefix PATH : ${paths}
+''


### PR DESCRIPTION
* Update `generate_packages.sh` structure to split its code to separate steps
* Add `update_flake` to `generate_packages.sh` script
* Add `generate_packages` package to nix packages to be able to run `nix run .#generate_packages` with no need to install dependencies manually
