### PR TITLE
CI: Add upload to release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           file: dist/*
-          tag: ${{ github.ref }}
+          tag: ${{ steps.data.outputs.release }}
           overwrite: true
           file_glob: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,4 +55,29 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ./result/*
-          name: nix-package
+          name: nix-
+          
+  upload-release:
+    if: github.ref == 'refs/heads/master'
+    needs: [build, nix-build]
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: dist
+
+      - id: data
+        uses: pozetroninc/github-action-get-latest-release@v0.7.0
+        with:
+          repository: ${{ github.event.repository.name }}
+
+      - name: Upload files to a GitHub release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: dist/*
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+
+      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ./result/*
-          name: nix-
+          name: nix-package
           
   upload-release:
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
           
   upload-release:
     if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
     needs: [build, nix-build]
     steps:
       - name: Download artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       - id: data
         uses: pozetroninc/github-action-get-latest-release@v0.7.0
         with:
-          repository: ${{ github.event.repository.name }}
+          repository: ${{ github.repository }}
 
       - name: Upload files to a GitHub release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
@cucumber-sp:

> да, я бы просто заменял файлы в релизе для текущей версии новыми. То есть пока 5.0.8 то в релизе 5.0.8 заменял  существующие новыми. Если сможете реализовать то будет отлично

Пример выполнения:

https://github.com/Maks1mS/yandex-music-linux/actions/runs/7755796810
https://github.com/Maks1mS/yandex-music-linux/releases/tag/v5.0.8

Загружаю в последний релиз, но из-за `sh ./generate_packages.sh` версия в Github Releases != версии пакета.