### PR TITLE
[update/flake] Fix flake.lock update periodicity

### DIFF
--- a/generate_packages.sh
+++ b/generate_packages.sh
@@ -73,7 +73,10 @@ update_pkbuild() {
 update_flake() {
     sed -i 's#\(ymExe\.url\s*=\s*\).*;#\1'"$exe_link"';#' ./flake.nix
     if check_dep nix; then
-        nix --extra-experimental-features 'nix-command flakes' flake update
+        nix --extra-experimental-features 'nix-command flakes' flake lock update --update-input ymExe
+        if [[ $(git status --porcelain) ]]; then
+            nix --extra-experimental-features 'nix-command flakes' flake update
+        fi
     else
         echo "flake.nix was updated, but nix is not installed to update flake.lock"
     fi


### PR DESCRIPTION
Check if exe binary was updated first, then update all flake.lock only when exe was updated.
