### PR TITLE
Add user flags config

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="Yandex Music - Personal recommendations, selections for any occasion an
 arch=("any")
 url="https://github.com/cucumber-sp/yandex-music-linux"
 license=("custom")
-depends=("electron27" "libpulse" "xdg-utils")
+depends=("electron28" "libpulse" "xdg-utils")
 makedepends=("p7zip" "nodejs" "asar" "jq" "python")
 
 source=("https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.0.14.exe" "git+https://github.com/cucumber-sp/yandex-music-linux")
@@ -31,8 +31,6 @@ package() {
     install -Dm644 "$srcdir/yandex-music-linux/templates/desktop" "$pkgdir/usr/share/applications/yandex-music.desktop"
     install -Dm644 "$srcdir/yandex-music-linux/LICENSE.md" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
-    # Create a script to launch the app with Electron
-    echo "#!/bin/sh" > "$pkgdir/usr/bin/yandex-music"
-    echo 'exec electron27 /usr/lib/yandex-music/yandex-music.asar "$@"' >> "$pkgdir/usr/bin/yandex-music"
-    chmod 755 "$pkgdir/usr/bin/yandex-music"
+    # Launcher
+    install -Dm755 "$srcdir/yandex-music-linux/templates/${pkgname}.sh" "$pkgdir/usr/bin/${pkgname}"
 }

--- a/templates/yandex-music.sh
+++ b/templates/yandex-music.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
-CONFIG_FILE_NAME=yandex-music-flags.conf
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+CONFIG_FILE_NAME="yandex-music-flags.conf"
 
 if [[ -f $XDG_CONFIG_HOME/$CONFIG_FILE_NAME ]]; then
-   YANDEX_MUSIC_USER_FLAGS="$(sed 's/#.*//' $XDG_CONFIG_HOME/$CONFIG_FILE_NAME | tr '\n' ' ')"
+   YANDEX_MUSIC_USER_FLAGS="$(sed 's/#.*//' ${XDG_CONFIG_HOME}/${CONFIG_FILE_NAME} | tr '\n' ' ')"
    echo "User flags:" "${YANDEX_MUSIC_USER_FLAGS[@]}"
 fi
 
 # Launch
-exec electron28 /usr/lib/yandex-music/yandex-music.asar $YANDEX_MUSIC_USER_FLAGS "$@" 
+exec electron28 /usr/lib/yandex-music/yandex-music.asar ${YANDEX_MUSIC_USER_FLAGS} "$@" 

--- a/templates/yandex-music.sh
+++ b/templates/yandex-music.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
+CONFIG_FILE_NAME=yandex-music-flags.conf
+
+if [[ -f $XDG_CONFIG_HOME/$CONFIG_FILE_NAME ]]; then
+   YANDEX_MUSIC_USER_FLAGS="$(sed 's/#.*//' $XDG_CONFIG_HOME/$CONFIG_FILE_NAME | tr '\n' ' ')"
+   echo "User flags:" "${YANDEX_MUSIC_USER_FLAGS[@]}"
+fi
+
+# Launch
+exec electron28 /usr/lib/yandex-music/yandex-music.asar $YANDEX_MUSIC_USER_FLAGS "$@" 


### PR DESCRIPTION
1. Added to the launch script the ability to use user config for flags. 
E.g. electron flags to use wayland:
`--enable-features=UseOzonePlatform --ozone-platform=wayland`

2. Changed version of Electron27 to Electron28, without this app launch with errors.