### PR TITLE
Wayland support

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="Yandex Music - Personal recommendations, selections for any occasion an
 arch=("any")
 url="https://github.com/cucumber-sp/yandex-music-linux"
 license=("custom")
-depends=("electron27" "libpulse" "xdg-utils")
+depends=("electron28" "libpulse" "xdg-utils")
 makedepends=("p7zip" "nodejs" "asar" "jq" "python")
 
 source=("https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.0.14.exe" "git+https://github.com/cucumber-sp/yandex-music-linux")
@@ -31,8 +31,11 @@ package() {
     install -Dm644 "$srcdir/yandex-music-linux/templates/desktop" "$pkgdir/usr/share/applications/yandex-music.desktop"
     install -Dm644 "$srcdir/yandex-music-linux/LICENSE.md" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
-    # Create a script to launch the app with Electron
-    echo "#!/bin/sh" > "$pkgdir/usr/bin/yandex-music"
-    echo 'exec electron27 /usr/lib/yandex-music/yandex-music.asar "$@"' >> "$pkgdir/usr/bin/yandex-music"
-    chmod 755 "$pkgdir/usr/bin/yandex-music"
+    touch electron-path
+    install -Dm644 electron-path "$pkgdir/usr/lib/yandex-music/electron-path"
+    echo '/usr/bin/electron28' >> "$pkgdir/usr/lib/yandex-music/electron-path"
+
+    # Launcher
+    install -Dm755 "$srcdir/yandex-music-linux/templates/${pkgname}.sh" "$pkgdir/usr/bin/${pkgname}"
 }
+

--- a/templates/yandex-music.sh
+++ b/templates/yandex-music.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ELECTRON_PATH=$(tr '\n' ' ' < /usr/lib/yandex-music/electron-path)
+
+if [ "$XDG_SESSION_TYPE" == "wayland" ]; then
+    WAYLAND_FLAGS="--enable-features=UseOzonePlatform --ozone-platform=wayland"
+fi
+
+# Launch
+exec ${ELECTRON_PATH} /usr/lib/yandex-music/yandex-music.asar ${WAYLAND_FLAGS} "$@"


### PR DESCRIPTION
1. The application will launch with flags for wayland if the current window system is wayland

2. During installation a file will be created containing the path to electron (Perhaps this can be done in a better way)

3. Changed version of Electron27 to Electron28, without this app launch with errors.

---

I think adding a config for custom flags is unnecessary. Flags for wayland will be enough.

If this script is suitable, it can be implemented for other distributions as well.