### PR TITLE
Revert "Fetch remote release notes"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       image: archlinux:latest
     steps:
       - name: Install packages
-        run: pacman -Syy -q --noconfirm && pacman -S -q --noconfirm git sudo base-devel p7zip nodejs jq asar dpkg unzip python python-requests rpm-tools glibc icu
+        run: pacman -Syy -q --noconfirm && pacman -S -q --noconfirm git sudo base-devel p7zip nodejs jq asar dpkg unzip python rpm-tools glibc icu
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/repack.sh
+++ b/repack.sh
@@ -135,6 +135,6 @@ asar pack "$TEMPDIR/app" "$dst/yandex-music.asar"
 for ext in png svg; do
     mv "$TEMPDIR/app/app/favicon.$ext" "$dst"
 done
-python "$SCRIPT_DIR/utility/extract_release_notes.py" "$dst/release_notes.json"
+python "$SCRIPT_DIR/utility/extract_release_notes.py" "$TEMPDIR/app/main/translations/compiled/ru.json" "$dst/release_notes.json"
 
 echo "Done"

--- a/utility/extract_release_notes.py
+++ b/utility/extract_release_notes.py
@@ -1,12 +1,12 @@
 import json
 import sys
-import requests
 
-if len(sys.argv) < 2:
-    print("Usage: python extract_release_notes.py <save_file_name>")
+if len(sys.argv) < 3:
+    print("Usage: python extract_release_notes.py <file_name>")
     sys.exit(1)
 
-save_file_name = sys.argv[1]
+file_name = sys.argv[1]
+save_file_name = sys.argv[2]
 
 
 def build_html(data, first_launch=False):
@@ -25,18 +25,15 @@ def build_html(data, first_launch=False):
     return html
 
 
-response = requests.get("https://music-desktop-application.s3.yandex.net/stable/release-notes/ru.json")
-if not response.ok:
-    print("Failed to download file")
-    sys.exit(1)
+with open(file_name, "r", encoding='utf-8') as file:
+    translation = json.load(file)
 
 notes = {}
 element_key: str
-for element_key in response.json().keys():
+for element_key in translation.keys():
     if not element_key.startswith("desktop-release-notes."):
         continue
-    notes[element_key] = build_html(response.json()[element_key], True)
+    notes[element_key] = build_html(translation[element_key], True)
 
 with open(save_file_name, "w", encoding='utf-8') as file:
     file.write(json.dumps(notes, ensure_ascii=False, indent=4))
-


### PR DESCRIPTION
That patch was pretty bad.

1. It breaks reliability of building packages for platforms without sandboxes
2. It brakes sandboxed build at all
3. It downloads unreliable data which may be not related to target build.

Suggestions to proceed. Better to configure CI on GitHub to automatically download and commit "release notes" data with package updating.