### PR TITLE
Remove unused uncertain variable

### DIFF
--- a/utility/extract_release_notes.py
+++ b/utility/extract_release_notes.py
@@ -31,7 +31,6 @@ if not response.ok:
     sys.exit(1)
 
 notes = {}
-element_key: str
 for element_key in response.json().keys():
     if not element_key.startswith("desktop-release-notes."):
         continue


### PR DESCRIPTION
In Python for cycles we don't need to create variables before a constructions `for` or `while` like this:

```python
i: int
for i in range(10):
    ...
```
In our case we add values for dictionary and `element_key` is unused var.