### PR TITLE
Update electronjs to 34.x.x

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="Yandex Music - Personal recommendations, selections for any occasion an
 arch=("any")
 url="https://github.com/cucumber-sp/yandex-music-linux"
 license=("Unlicense")
-depends=("electron32" "libpulse" "xdg-utils" "bash" "hicolor-icon-theme")
+depends=("electron34" "libpulse" "xdg-utils" "bash" "hicolor-icon-theme")
 makedepends=("p7zip" "nodejs" "asar" "jq" "python" "git")
 
 source=("https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.37.1.exe" "git+${url}#tag=v${pkgver}")
@@ -35,6 +35,6 @@ package() {
     install -Dm644 "$srcdir/yandex-music-linux/LICENSE.md" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
     install -Dm755 "$srcdir/yandex-music-linux/templates/yandex-music.sh" "$pkgdir/usr/bin/yandex-music"
-    sed -i "s|%electron_path%|/usr/bin/electron32|g" "$pkgdir/usr/bin/yandex-music"
+    sed -i "s|%electron_path%|/usr/bin/electron34|g" "$pkgdir/usr/bin/yandex-music"
     sed -i "s|%asar_path%|/usr/lib/yandex-music/yandex-music.asar|g" "$pkgdir/usr/bin/yandex-music"
 }

--- a/templates/PKGBUILD
+++ b/templates/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="Yandex Music - Personal recommendations, selections for any occasion an
 arch=("any")
 url="https://github.com/cucumber-sp/yandex-music-linux"
 license=("Unlicense")
-depends=("electron32" "libpulse" "xdg-utils" "bash" "hicolor-icon-theme")
+depends=("electron34" "libpulse" "xdg-utils" "bash" "hicolor-icon-theme")
 makedepends=("p7zip" "nodejs" "asar" "jq" "python" "git")
 
 source=("%exe_link%" "git+${url}#tag=v${pkgver}")
@@ -35,6 +35,6 @@ package() {
     install -Dm644 "$srcdir/yandex-music-linux/LICENSE.md" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
     install -Dm755 "$srcdir/yandex-music-linux/templates/yandex-music.sh" "$pkgdir/usr/bin/yandex-music"
-    sed -i "s|%electron_path%|/usr/bin/electron32|g" "$pkgdir/usr/bin/yandex-music"
+    sed -i "s|%electron_path%|/usr/bin/electron34|g" "$pkgdir/usr/bin/yandex-music"
     sed -i "s|%asar_path%|/usr/lib/yandex-music/yandex-music.asar|g" "$pkgdir/usr/bin/yandex-music"
 }

--- a/utility/update_version.py
+++ b/utility/update_version.py
@@ -51,7 +51,7 @@ print(f"Sha256: {exe_sha256}")
 print("Getting latest electron version")
 electron_releases = requests.get(ELECTRON_VERSIONS_URL).json()
 electron_versions = list(map(lambda x: x["version"], electron_releases))
-electron_versions = list(filter(lambda x: "-" not in x and x.startswith("32"), electron_versions))
+electron_versions = list(filter(lambda x: "-" not in x and x.startswith("34"), electron_versions))
 electron_version = electron_versions[0]
 print(f"Latest electron version: {electron_version}")
 electron_x64 = ELECTRON_DOWNLOAD_URL.format(electron_version, "x64")


### PR DESCRIPTION
Debian sid, KDE 6.2, Wayland

Before:

![image](https://github.com/user-attachments/assets/01ec8077-6cd1-47de-bb00-cff74bfd6c22)

After:

![image](https://github.com/user-attachments/assets/0eee7208-bb6a-4921-8af3-3fa5fb4a0673)

Fixes on chromium 131.0.6738.0 [issue](https://issues.chromium.org/issues/331796411)
Electronjs updated on 34.0.0, [release notes](https://releases.electronjs.org/release/v34.0.0)