### PR TITLE
Disable autoupdates and block telemetry

### DIFF
--- a/patches/0005-Disable-autoupdates-and-block-telemetry.patch
+++ b/patches/0005-Disable-autoupdates-and-block-telemetry.patch
@@ -1,0 +1,23 @@
+diff --git a/main/index.js b/main/index.js
+--- a/main/index.js
++++ b/main/index.js
+@@ -34,2 +34,7 @@  exports.config = {
+     const window = await (0, createWindow_js_1.createWindow)();
++    const { session } = require("electron");
++
++    session.defaultSession.webRequest.onBeforeRequest({ urls: ["https://yandex.ru/clck/*", "https://mc.yandex.ru/*"] }, (details, callback) => {
++       callback({ cancel: true });
++    });
+     const isPlatformWindows = deviceInfo_js_1.devicePlatform === platform_js_1.Platform.WINDOWS;
+
+
+diff --git a/main/config.js b/main/config.js
+--- a/main/config.js
++++ b/main/config.js
+@@ -11,4 +11,4 @@ exports.config = {
+     enableWebSecurity: true,
+-    enableAutoUpdate: true,
+-    enableUpdateByProbability: true,
++    enableAutoUpdate: false,
++    enableUpdateByProbability: false,
+     bypassCSP: false,


### PR DESCRIPTION
Пока клиент не официальный, в автоматических обновлениях необходимости нет. Аналогично и с телеметрией. На запоминание текущего трека и позиции влияния не оказывает. Тестировал больше недели, проблем не обнаружил.