### PR TITLE
Nix tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,3 +101,20 @@ jobs:
       - name: Build yandex-music without flakes binaries
         run: nix build --impure .#yandex-music-noflakes
 
+  nix-test:
+    runs-on: ubuntu-latest
+    env:
+      NIXPKGS_ALLOW_UNFREE: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ (inputs.ref || '') }}
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v22
+
+      - uses: DeterminateSystems/magic-nix-cache-action@v2
+
+      - name: Run NixOS tests
+        run: nix build --impure .#tests

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Native YandexMusic client for Linux. Built using repacking of Windows client (El
       - [Run with flakes](#run-with-flakes)
       - [Run old style](#run-old-style)
       - [Install to NixOS](#install-to-nixos)
+   - [NixOS tests](#nixos-tests)
 - [Star History](#star-history)
 
 
@@ -337,6 +338,40 @@ nix-build --expr '(import <nixpkgs> {}).callPackage ./nix {}'
     programs.yandex-music.enable = true;
     programs.yandex-music.tray.enable = true; # to enable tray support
     ```
+#### NixOS tests
+
+This project uses [NixOS Testing
+framework](https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests) to
+perform generic run-tests of NixOS module and built app.
+
+It runs automatically by github actions, but you may want to perform tests on
+your own PC.
+
+The root flake exports package `tests` with symlinks to artefact of all tests.
+
+So you can run them by
+
+```bash
+nix build .#tests
+```
+
+Each test is complete qemu VM with NixOS onboard and configured yandex-music
+application. The test performs withing the result package building inside nix
+sandbox. The simple python script perform all the basic checks. The tests are
+differs between each other by configuration options to yandex-music module. You
+can see all of them [here](./nix/test.nix#L46).
+
+You can run each test separately as sub-attr of `tests` package, e.g:
+
+```bash
+nix build .#tests.trayMonoWhite
+```
+
+You may want to see logs of each test (even failed) with `nix log` command, e.g:
+
+```bash
+nix log .#tests.customTitleBar
+```
 
 ## Star History
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -19,16 +19,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708093448,
-        "narHash": "sha256-gohEm3/NVyu7WINFhRf83yJH8UM2ie/KY9Iw3VN6fiE=",
-        "owner": "NixOS",
+        "lastModified": 1741379970,
+        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c7763249f02b7786b4ca36e13a4d7365cfba162f",
+        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
@@ -56,13 +58,13 @@
     "ymExe": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-JPwe9Pqwytze3O1lB9yzeA3Th+Ni9ZVuOjjCa8BwH9s=",
+        "narHash": "sha256-4rhdb0Mz3LosMj0GlIkOuryNXcLl+DSOp+WIe30a1lY=",
         "type": "file",
-        "url": "https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.39.0.exe"
+        "url": "https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.41.1.exe"
       },
       "original": {
         "type": "file",
-        "url": "https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.39.0.exe"
+        "url": "https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.41.1.exe"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -21,12 +21,17 @@
         pkgs.callPackage ./nix {
           inherit ymExe;
         };
-      modules = isHm: rec {
-        yandex-music = {
-          imports = [ (import ./nix/module.nix { inherit isHm yandex-music-with; }) ];
+      modules =
+        {
+          isHm ? false,
+          isTest ? false,
+        }:
+        rec {
+          yandex-music = {
+            imports = [ (import ./nix/module.nix { inherit isHm isTest yandex-music-with; }) ];
+          };
+          default = yandex-music;
         };
-        default = yandex-music;
-      };
     in
     flake-utils.lib.eachDefaultSystem (
       system:
@@ -38,13 +43,17 @@
           yandex-music = yandex-music-with pkgs;
           yandex-music-noflakes = pkgs.callPackage ./nix { };
           default = yandex-music;
+          tests = pkgs.callPackage ./nix/test.nix {
+            nixosModule = (modules { isTest = true; }).yandex-music;
+            inherit yandex-music-with;
+          };
         };
         formatter = pkgs.nixfmt-rfc-style;
       }
     )
     // {
-      nixosModules = modules false;
-      homeManagerModules = modules true;
+      nixosModules = modules { };
+      homeManagerModules = modules { isHm = true; };
 
       nixosModule = self.nixosModules.default;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,8 @@
   inputs = {
     ymExe.url = "https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.41.1.exe";
     ymExe.flake = false;
+
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
   outputs = { self, ymExe, nixpkgs, flake-utils }:

--- a/flake.nix
+++ b/flake.nix
@@ -8,11 +8,19 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, ymExe, nixpkgs, flake-utils }:
+  outputs =
+    {
+      self,
+      ymExe,
+      nixpkgs,
+      flake-utils,
+    }:
     let
-      yandex-music-with = pkgs: pkgs.callPackage ./nix {
-        inherit ymExe;
-      };
+      yandex-music-with =
+        pkgs:
+        pkgs.callPackage ./nix {
+          inherit ymExe;
+        };
       modules = isHm: rec {
         yandex-music = {
           imports = [ (import ./nix/module.nix { inherit isHm yandex-music-with; }) ];
@@ -20,19 +28,21 @@
         default = yandex-music;
       };
     in
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = import nixpkgs { inherit system; };
-        in
-        {
-          packages = rec {
-            yandex-music = yandex-music-with pkgs;
-            yandex-music-noflakes = pkgs.callPackage ./nix { };
-            default = yandex-music;
-          };
-        }
-      ) // {
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages = rec {
+          yandex-music = yandex-music-with pkgs;
+          yandex-music-noflakes = pkgs.callPackage ./nix { };
+          default = yandex-music;
+        };
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    )
+    // {
       nixosModules = modules false;
       homeManagerModules = modules true;
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,22 +1,23 @@
-{ fetchurl
-, stdenvNoCC
-, lib
-, makeWrapper
+{
+  fetchurl,
+  stdenvNoCC,
+  lib,
+  makeWrapper,
 
-, p7zip
-, asar
-, jq
-, python3
-, electron
+  p7zip,
+  asar,
+  jq,
+  python3,
+  electron,
 
-, ymExe ? null
-, electronArguments ? ""
-, trayEnabled ? false
-, trayStyle ? 1
-, trayAlways ? false
-, devTools ? false
-, vibeAnimationMaxFps ? 25
-, customTitleBar ? false
+  ymExe ? null,
+  electronArguments ? "",
+  trayEnabled ? false,
+  trayStyle ? 1,
+  trayAlways ? false,
+  devTools ? false,
+  vibeAnimationMaxFps ? 25,
+  customTitleBar ? false,
 }:
 let
   inherit (lib) optionalString assertMsg;
@@ -24,8 +25,7 @@ let
 in
 assert assertMsg (trayStyle >= 1 && trayStyle <= 3) "Tray style must be withing 1 and 3";
 assert assertMsg (vibeAnimationMaxFps >= 0) "Vibe animation max FPS must be greater then 0";
-stdenvNoCC.mkDerivation
-{
+stdenvNoCC.mkDerivation {
   name = "yandex-music";
   inherit (version_info.ym) version;
 
@@ -44,8 +44,8 @@ stdenvNoCC.mkDerivation
   desktopItem = ../templates/desktop;
   ymScript = ../templates/yandex-music.sh;
   src =
-    if ymExe != null
-    then ymExe
+    if ymExe != null then
+      ymExe
     else
       fetchurl {
         url = version_info.ym.exe_link;
@@ -61,18 +61,23 @@ stdenvNoCC.mkDerivation
   '';
   dontPatch = true;
 
-  config =''
-    ELECTRON_ARGS="${electronArguments}"
-    VIBE_ANIMATION_MAX_FPS=${toString vibeAnimationMaxFps}
-  '' + optionalString trayEnabled ''
-    TRAY_ENABLED=${toString trayStyle}
-  '' + optionalString trayAlways ''
-    ALWAYS_LEAVE_TO_TRAY=1
-  '' + optionalString devTools ''
-    DEV_TOOLS=1
-  '' + optionalString customTitleBar ''
-    CUSTOM_TITLE_BAR=1
-  '';
+  config =
+    ''
+      ELECTRON_ARGS="${electronArguments}"
+      VIBE_ANIMATION_MAX_FPS=${toString vibeAnimationMaxFps}
+    ''
+    + optionalString trayEnabled ''
+      TRAY_ENABLED=${toString trayStyle}
+    ''
+    + optionalString trayAlways ''
+      ALWAYS_LEAVE_TO_TRAY=1
+    ''
+    + optionalString devTools ''
+      DEV_TOOLS=1
+    ''
+    + optionalString customTitleBar ''
+      CUSTOM_TITLE_BAR=1
+    '';
 
   installPhase = ''
     mkdir -p "$out/share/nodejs"
@@ -101,7 +106,10 @@ stdenvNoCC.mkDerivation
     homepage = "https://music.yandex.ru/";
     downloadPage = "https://music.yandex.ru/download/";
     license = lib.licenses.unfree;
-    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     maintainers = [
       {
         name = "Yury Shvedov";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,19 +1,27 @@
-{ yandex-music-with
-, isHm ? false
+{
+  yandex-music-with,
+  isHm ? false,
 }:
-{ lib, pkgs, config, ... }:
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
 let
   cfg = config.programs.yandex-music;
 
 in
 {
-  imports = [{
-    nixpkgs.overlays = [
-      (final: prev: {
-        yandex-music = yandex-music-with prev;
-      })
-    ];
-  }];
+  imports = [
+    {
+      nixpkgs.overlays = [
+        (final: prev: {
+          yandex-music = yandex-music-with prev;
+        })
+      ];
+    }
+  ];
 
   options = {
     programs.yandex-music = {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,6 +1,7 @@
 {
   yandex-music-with,
   isHm ? false,
+  isTest ? false,
 }:
 {
   lib,
@@ -13,14 +14,18 @@ let
 
 in
 {
+  /*
+    The NixOS test framework disallow to extend `nixpkgs.overlays` configuration
+    option, so we make it here conditionally.
+  */
   imports = [
-    {
+    (lib.mkIf (!isTest) {
       nixpkgs.overlays = [
         (final: prev: {
           yandex-music = yandex-music-with prev;
         })
       ];
-    }
+    })
   ];
 
   options = {

--- a/nix/test-suite.nix
+++ b/nix/test-suite.nix
@@ -1,0 +1,62 @@
+/*
+  This test suite uses nixos common x11 and user-account test configurations.
+  Those configurations use auto-login to ice-wm desktop manager.
+  This test configuration enables yandex-music application, launches it and
+  check for window existence. Additionally it takes screenshot after successful
+  launch to allow to validate state manually. The result may miss the content
+  inside window because of lack of GPU support.
+
+  TODO(Shvedov): We should to perform automatic checks of screen state.
+*/
+{
+  testers,
+  path,
+
+  # The yandex-music module
+  nixosModule,
+  # The extra configuration
+  configuration ? { },
+  # The extra code of test script
+  extraTestScript ? "",
+  # The name of test
+  name ? "yandex-music-test",
+}:
+testers.runNixOSTest {
+  inherit name;
+  nodes.machine =
+    let
+      tests = "${path}/nixos/tests/common/";
+      user = "alice";
+    in
+    {
+      imports = [
+        nixosModule
+        "${tests}/x11.nix"
+        "${tests}/user-account.nix"
+        configuration
+      ];
+      test-support.displayManager.auto.user = user;
+      programs.yandex-music.enable = true;
+    };
+
+  testScript =
+    ''
+      # We have to execute command with su beckause all commands performs under
+      # the root user.
+      def mk_command(command, tail = "", fork = False):
+        if fork:
+          tail = f"{tail} >&2 &"
+        return f"su -c '{command}' - alice {tail}"
+
+      machine.wait_for_x()
+      machine.execute(mk_command("yandex-music", fork = True))
+
+      check_command = mk_command('xwininfo -root -tree', tail = "| grep 'Яндекс Музыка'")
+
+      machine.wait_until_succeeds(check_command, 120)
+      machine.sleep(40)
+      machine.succeed(check_command)
+      machine.screenshot("screen")
+    ''
+    + extraTestScript;
+}

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -1,0 +1,81 @@
+/*
+  This is set of tests of yandex-music application. The main purpose of this
+  test is to check the NixOS module for yandex-music and whether its runs
+  successfully with such configuration.
+*/
+{
+  pkgs,
+  yandex-music-with,
+  nixosModule,
+  linkFarm,
+  lib,
+}:
+let
+  # Extend packages with our package to overcome the limitation of nixOSTest
+  # modules regarding the overlays.
+  pkgs' = pkgs.extend (cur: prev: { yandex-music = yandex-music-with prev; });
+  removeNameAttr = attrs: lib.removeAttrs attrs [ "name" ];
+  test-suite =
+    {
+      name ? "yandex-music-test",
+      ...
+    }@configuration:
+    pkgs'.callPackage ./test-suite.nix {
+      inherit nixosModule name;
+      configuration = removeNameAttr configuration;
+    };
+  yandex-music-config = cfg: {
+    programs.yandex-music = cfg;
+  };
+  yandex-music-test-suite =
+    {
+      name,
+      ...
+    }@cfg:
+    test-suite (
+      (yandex-music-config (removeNameAttr cfg))
+      // {
+        name = "yandex-music-test-${name}";
+      }
+    );
+  /*
+    This is set of similar tests with slightly different configuration options
+    for yandex-music module. All they will be joined together to package with
+    symlinks to all results.
+  */
+  tests = {
+    base = test-suite { };
+    trayDefault = yandex-music-test-suite {
+      tray.enable = true;
+      name = "tray-default";
+    };
+    trayAlways = yandex-music-test-suite {
+      tray.enable = true;
+      tray.always = true;
+      name = "tray-always";
+    };
+    trayMonoBlack = yandex-music-test-suite {
+      tray.enable = true;
+      tray.style = 2;
+      name = "tray-mono-black";
+    };
+    trayMonoWhite = yandex-music-test-suite {
+      tray.enable = true;
+      tray.style = 3;
+      name = "tray-mono-white";
+    };
+    devTools = yandex-music-test-suite {
+      devTools.enable = true;
+      name = "dev-tools";
+    };
+    customTitleBar = yandex-music-test-suite {
+      customTitleBar.enable = true;
+      name = "custom-title-bar";
+    };
+    animatiosFpsZero = yandex-music-test-suite {
+      vibeAnimationMaxFps = 0;
+      name = "animation-fps-zero";
+    };
+  };
+in
+(linkFarm "yandex-music-test-all" tests) // tests


### PR DESCRIPTION
Introduce tests based on [NixOS Testing framework](https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests) to perform generic run-tests of NixOS module and built app.

See [readme](https://github.com/ein-shved/yandex-music-linux/blob/nix-tests/README.md#nixos-tests) for more