### PR TITLE
Fix window icon

### DIFF
--- a/patches/0006-Fix-window-icon.patch
+++ b/patches/0006-Fix-window-icon.patch
@@ -1,0 +1,7 @@
+diff --git a/main/lib/createWindow.js b/main/lib/createWindow.js
+--- a//main/lib/createWindow.js
++++ b//main/lib/createWindow.js
+@@ -56,2 +56,3 @@ exports.config = {
+         height: 800,
++        icon: node_path_1.default.join(__dirname, '../../app', 'favicon.png'),
+         webPreferences: {


### PR DESCRIPTION
Fix #147

Протестировано в Linux Mint 22.1 Xia / MATE 1.26.2 / X11
![image](https://github.com/user-attachments/assets/8c314e40-2617-40cd-b068-e4cb36212b4e)

В Kubuntu 22.10 / KDE 6.1.5 / Wayland не сломалось