### PR TITLE
Make the build of rpm, deb and tarball reproducible

### DIFF
--- a/build_deb.sh
+++ b/build_deb.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export SOURCE_DATE_EPOCH=1700000000
+
 usage() {
     echo "Usage: $(basename "$0")  [-h] [-a <x64|armv7l|arm64|all> default=x64]"
     echo
@@ -35,7 +37,9 @@ build_deb(){
     # extract tarball to pkgdir
     tar -xzf "${TEMPDIR}/yandex-music_${version}_${arch}.tar.gz" -C "${pkgdir}"
 
-    dpkg-deb --build "${pkgdir}" "deb/yandex-music_${version}_${pkgarch}.deb"
+    find "${pkgdir}" -exec touch -t "$(date -d "@${SOURCE_DATE_EPOCH}" +%Y%m%d%H%M.%S)" {} +
+    
+    dpkg-deb --root-owner-group --build "${pkgdir}" "deb/yandex-music_${version}_${pkgarch}.deb"
 }
 
 x64=0

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export SOURCE_DATE_EPOCH=1700000000 
+
 usage() {
     echo "Usage: $(basename "$0")  [-h] [-a <x64|armv7l|arm64|all> default=x64]"
     echo

--- a/build_tarball.sh
+++ b/build_tarball.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export SOURCE_DATE_EPOCH=1700000000
+
 usage() {
     echo "Usage: $(basename "$0")  [-h] [-a <x64|armv7l|arm64|all> default=x64]"
     echo
@@ -46,7 +48,12 @@ build_tarball(){
     sed -i "s|%asar_path%|/usr/lib/yandex-music/yandex-music.asar|g" "${app_dir}/usr/bin/yandex-music"
 
     cd "${app_dir}"
-    tar -czf "${OUTPUT_DIR}/yandex-music_${version}_${arch}.tar.gz" *
+
+    find . -print0 | LC_ALL=C sort -z | tar --null --files-from=- \
+        --owner=0 --group=0 --numeric-owner \
+        --mtime="@${SOURCE_DATE_EPOCH}" \
+        -cf - | gzip -n > "${OUTPUT_DIR}/yandex-music_${version}_${arch}.tar.gz"
+
     cd "${INITIAL_DIR}"
 }
 

--- a/templates/rpm.spec
+++ b/templates/rpm.spec
@@ -11,6 +11,10 @@ BuildArch: %arch%
 
 Requires: (kde-cli-tools or kde-cli-tools5 or kde-runtime or trash-cli or glib2 or gvfs-client), (libXtst or libXtst6), (libnotify or libnotify4), (libxcb or libxcb1), (mesa-libgbm or libgbm1), (nss or mozilla-nss), at-spi2-core, gtk3, libdrm, xdg-utils
 
+%define use_source_date_epoch_as_buildtime 1
+%define build_mtime_policy clamp_to_source_date_epoch
+%define buildhost reproducible
+
 %description
 Yandex Music - Personal recommendations, selections for any occasion and new music
 
@@ -18,8 +22,7 @@ Yandex Music - Personal recommendations, selections for any occasion and new mus
 %setup -q
 
 %install
-
-cp -r ./usr %{buildroot}/
+cp -rp ./usr %{buildroot}/
 chmod 755 %{buildroot}/usr/bin/yandex-music
 
 


### PR DESCRIPTION
В настоящее время workflow `Update, build and release` ежедневно пересобирает и обновляет последний релиз. Из-за отсутствия воспроизводимости сборки хэш-суммы файлов каждый день отличаются, хотя содержимое может и не меняться.

Я добавил поддержку воспроизводимой сборки в скрипты `build_{deb,rpm,tarball}.sh`. Проверить воспроизводимость можно следующим скриптом:
```bash
#!/bin/bash

test_build() {
    mkdir artifacts

    bash ./build_tarball.sh
    bash ./build_rpm.sh
    bash ./build_deb.sh

    mv ./tar/* artifacts
    mv ./rpm/* artifacts
    mv ./deb/* artifacts
}

rm -rf artifacts
rm -rf artifacts-prev

test_build

mv artifacts artifacts-prev

test_build

(cd artifacts-prev && find . -type f | sort | xargs sha256sum > ../checksums-prev.txt)
(cd artifacts && find . -type f | sort | xargs sha256sum > ../checksums.txt)

diff -u checksums-prev.txt checksums.txt
```