### PR TITLE
Update electron dependency in PKGBUILD to meta package

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -36,6 +36,6 @@ package() {
     install -Dm644 "$srcdir/yandex-music-linux/LICENSE.md" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
     install -Dm755 "$srcdir/yandex-music-linux/templates/yandex-music.sh" "$pkgdir/usr/bin/yandex-music"
-    sed -i "s|%electron_path%|/usr/bin/electron34|g" "$pkgdir/usr/bin/yandex-music"
+    sed -i "s|%electron_path%|/usr/bin/electron|g" "$pkgdir/usr/bin/yandex-music"
     sed -i "s|%asar_path%|/usr/lib/yandex-music/yandex-music.asar|g" "$pkgdir/usr/bin/yandex-music"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="Yandex Music - Personal recommendations, selections for any occasion an
 arch=("any")
 url="https://github.com/cucumber-sp/yandex-music-linux"
 license=("Unlicense")
-depends=("electron34" "libpulse" "xdg-utils" "bash" "hicolor-icon-theme")
+depends=("electron" "libpulse" "xdg-utils" "bash" "hicolor-icon-theme")
 makedepends=("p7zip" "nodejs" "asar" "jq" "python" "git")
 
 source=("https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.67.0.exe" "git+${url}#tag=v${pkgver}")


### PR DESCRIPTION
Personally I have meta electron package and electron37 is installed in my system. Maybe we should use meta package? If there are specific reasons to use electron34, please tell me. Thank for project!